### PR TITLE
overlay: disable menu key in lockscreen

### DIFF
--- a/overlay/frameworks/base/packages/Keyguard/res/values/config.xml
+++ b/overlay/frameworks/base/packages/Keyguard/res/values/config.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2009, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<!-- These resources are around just to allow their values to be customized
+     for different hardware and product builds. -->
+<resources>
+
+    <!-- disable menu hard key on Janice in non-pattern lockscreen -->
+    <bool name="config_disableMenuKeyInLockScreen">true</bool>
+
+</resources>


### PR DESCRIPTION
There is a bug in AOSP Lockscreen, tapping the menu button unlocks the phone.
This commit disables menu hard key on Janice in a non-pattern lockscreen to improve security.

Source:
https://github.com/omnirom/android_device_samsung_aries-common/commit/31af4c8c983df477fc88a2900582ffde0a708783?diff=unified
